### PR TITLE
Sw 9 training programs

### DIFF
--- a/death_star_711/settings.py
+++ b/death_star_711/settings.py
@@ -31,6 +31,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'rest_framework',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/death_star_data/serializers.py
+++ b/death_star_data/serializers.py
@@ -1,15 +1,6 @@
 from rest_framework import serializers
 from death_star_data.models import Customer, Product, ProductType, PaymentType, Order, ProductOrder, Department, Employee, Training, EmployeeTraining, Computer, ComputerEmployee
 
-<<<<<<< HEAD
-class TrainingSerializers(serializers.HyperlinkedModelSerializer):
-
-    class Meta:
-        model = Training
-        fields = ('id', 'name', 'start_date', 'end_date', 'max_attendees', 'url')
-
-        # TODO:  add  'employees'  to end of fields above once it is built
-=======
 '''
 
 Ticket #7
@@ -25,6 +16,12 @@ class EmployeeSerializer(serializers.HyperlinkedModelSerializer):
         model = Employee
         fields = ('id', 'first_name', 'last_name', 'start_date', 'is_supervisor', 'department')
 
+class TrainingSerializers(serializers.HyperlinkedModelSerializer):
+    employees = EmployeeSerializer(many=True, read_only=True)
+    class Meta:
+        model = Training
+        fields = ('id', 'name', 'start_date', 'end_date', 'max_attendees', 'employees', 'url')
+
 class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
     '''The following variable connects the FK of department on the employee model, which gives access to employee information through the serializer using many=True.
 
@@ -34,17 +31,13 @@ class DepartmentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Department
         fields = ('id', 'name', 'budget', 'url', 'employees')
->>>>>>> master
 
 class ProductTypeSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = ProductType
         fields = ('name',)
 
-<<<<<<< HEAD
-=======
 
->>>>>>> master
 class PaymentTypeSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:

--- a/death_star_data/serializers.py
+++ b/death_star_data/serializers.py
@@ -1,3 +1,10 @@
 from rest_framework import serializers
 from death_star_data.models import Customer, Product, ProductType, PaymentType, Order, ProductOrder, Department, Employee, Training, EmployeeTraining, Computer, ComputerEmployee
 
+class TrainingSerializers(serializers.HyperlinkedModelSerializer):
+
+    class Meta:
+        model = Training
+        fields = ('id', 'name', 'start_date', 'end_date', 'max_attendees', 'url')
+
+        # TODO:  add  'employees'  to end of fields above once it is built

--- a/death_star_data/urls.py
+++ b/death_star_data/urls.py
@@ -1,10 +1,11 @@
 from django.conf.urls import include
 from django.urls import path
 from rest_framework.routers import DefaultRouter
+from rest_framework import routers
 from death_star_data import views
 
 router = DefaultRouter()
-# router.register('movies', views.MovieViewSet)
+router.register('training', views.TrainingViewSet)
 
 urlpatterns = [
     path('', include(router.urls))

--- a/death_star_data/views.py
+++ b/death_star_data/views.py
@@ -1,17 +1,28 @@
 from django.shortcuts import render
-
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
-
+from rest_framework.decorators import action
 from rest_framework import filters
-
 from death_star_data.models import Customer, Product, ProductType, PaymentType, Order, ProductOrder, Department, Employee, Training, EmployeeTraining, Computer, ComputerEmployee
-from death_star_data.serializers import 
+from death_star_data.serializers import TrainingSerializers
 
 
 
 @api_view(['GET'])
 def api_root(request, format=None):
     return Response({
-         
+         'training': reverse('training', request=request, format=format),
     })
+
+class TrainingViewSet(viewsets.ModelViewSet):
+    queryset = Training.objects.all()
+    serializer_class = TrainingSerializers
+
+    def delete(self, pk, request):
+        password = request.data.get('password')
+        article_id = request.data.get('article')
+        article_instance = article.objects.get(id=article_id)
+        if password == article_instance.password:
+            article_instance.delete()
+            return Response(status=status.HTTP_200_OK)
+        return Response(status=status.HTTP_304_NOT_MODIFIED)

--- a/death_star_data/views.py
+++ b/death_star_data/views.py
@@ -2,9 +2,9 @@ from django.shortcuts import render
 from rest_framework import viewsets
 from rest_framework.decorators import api_view
 from rest_framework.decorators import action
-from rest_framework import filters
 from death_star_data.models import Customer, Product, ProductType, PaymentType, Order, ProductOrder, Department, Employee, Training, EmployeeTraining, Computer, ComputerEmployee
 from death_star_data.serializers import TrainingSerializers
+import datetime
 
 
 
@@ -14,15 +14,30 @@ def api_root(request, format=None):
          'training': reverse('training', request=request, format=format),
     })
 
+
 class TrainingViewSet(viewsets.ModelViewSet):
     queryset = Training.objects.all()
     serializer_class = TrainingSerializers
+    
 
-    def delete(self, pk, request):
-        password = request.data.get('password')
-        article_id = request.data.get('article')
-        article_instance = article.objects.get(id=article_id)
-        if password == article_instance.password:
-            article_instance.delete()
-            return Response(status=status.HTTP_200_OK)
-        return Response(status=status.HTTP_304_NOT_MODIFIED)
+    def get_queryset(self):
+        current_date = datetime.date.today()
+        query_set = Training.objects.all()
+        keyword = self.request.query_params.get('completed')
+        if keyword == 'true':    
+            print("query params", keyword)
+            print("HERE", current_date)
+            query_set = query_set.filter(end_date__lt=current_date)
+        elif keyword == 'false':
+            query_set = query_set.filter(end_date__gte=current_date)
+        return query_set
+    
+
+    
+    
+
+
+  
+
+    
+        

--- a/death_star_data/views.py
+++ b/death_star_data/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render
-from rest_framework import viewsets, filters
+from rest_framework import viewsets
+from rest_framework import filters
 from rest_framework.decorators import api_view
 from rest_framework.decorators import action
-from rest_framework import filters
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 
@@ -29,7 +29,6 @@ class TrainingViewSet(viewsets.ModelViewSet):
     queryset = Training.objects.all()
     serializer_class = TrainingSerializers
     
-
     def get_queryset(self):
         ''' Assigns the keyword of completed. Then filters through our query set of training programs and evaluate
         whether current time is greater than(gte) or lesser than(lt) then return the query_set '''
@@ -41,6 +40,8 @@ class TrainingViewSet(viewsets.ModelViewSet):
         elif keyword == 'false':
             query_set = query_set.filter(end_date__gte=current_date)
         return query_set
+
+    
 class EmployeeViewSet(viewsets.ModelViewSet):
     queryset = Employee.objects.all()
     serializer_class = EmployeeSerializer

--- a/death_star_data/views.py
+++ b/death_star_data/views.py
@@ -22,17 +22,21 @@ def api_root(request, format=None):
     })
 
 class TrainingViewSet(viewsets.ModelViewSet):
+    '''Will get us a list of training programs as well as the ability to view a program individually.
+       A list of employees who signed up for a training program will be visable.
+       Able to view only programs starting today, or in the future, with the `?completed=false` query string parameter.
+     '''
     queryset = Training.objects.all()
     serializer_class = TrainingSerializers
     
 
     def get_queryset(self):
+        ''' Assigns the keyword of completed. Then filters through our query set of training programs and evaluate
+        whether current time is greater than(gte) or lesser than(lt) then return the query_set '''
         current_date = datetime.date.today()
         query_set = Training.objects.all()
         keyword = self.request.query_params.get('completed')
-        if keyword == 'true':    
-            print("query params", keyword)
-            print("HERE", current_date)
+        if keyword == 'true':
             query_set = query_set.filter(end_date__lt=current_date)
         elif keyword == 'false':
             query_set = query_set.filter(end_date__gte=current_date)


### PR DESCRIPTION
## Link to Ticket
Closes # [Ticket 9](https://github.com/chatty-clownfish/bangazon_sprint_3/issues/9)

## Description of Proposed Changes

- User should be able to GET a list, and GET a single item.
- Employees who signed up for a training program should be included in the response
- Should be able to view only programs starting today, or in the future, with the `?completed=false` query string parameter.

## Steps to Test

Outline the steps to test

```sh
git fetch --all
git checkout SW-9-training-programs
```
- If you insert the following link into your browser you should only see training programs that have not happened yet. If you switch the false to true you will only see ones that have already taken place.  http://localhost:8000/training/?completed=false

## Impacted Areas in Application

List general components of the application that this PR will affect:

* training programs


