### PR TITLE
Sw 9 clean up

### DIFF
--- a/death_star_data/views.py
+++ b/death_star_data/views.py
@@ -28,7 +28,17 @@ class TrainingViewSet(viewsets.ModelViewSet):
      '''
     queryset = Training.objects.all()
     serializer_class = TrainingSerializers
-    
+    current_date = datetime.date.today()
+
+    def destroy(self, request, *args, **kwargs):
+        query_set = self.get_object()
+        if self.current_date >= query_set.end_date:
+            print('LESS THAN =', query_set.end_date)
+            # TODO:Make alert message to tell the user that they cannot delete past events
+        elif self.current_date < query_set.end_date:
+            query_set.delete()
+        return query_set
+
     def get_queryset(self):
         ''' Assigns the keyword of completed. Then filters through our query set of training programs and evaluate
         whether current time is greater than(gte) or lesser than(lt) then return the query_set '''


### PR DESCRIPTION
## Link to Ticket
Closes # [ticket 9](https://github.com/chatty-clownfish/bangazon_sprint_3/issues/9)

## Description of Proposed Changes

- user is no longer able to delete a training program that has already occurred 

## Steps to Test

Outline the steps to test

```sh
git fetch --all
git checkout SW-9-clean-up
```
go to a specific training program and try to delete it. You should only be able to delete ones where the end date is before today


## Impacted Areas in Application

List general components of the application that this PR will affect:

* 

## Mentions @username

Tag users that need to review this code
